### PR TITLE
Clean up hisatgenotype

### DIFF
--- a/hisatgenotype
+++ b/hisatgenotype
@@ -22,19 +22,18 @@
 import sys
 import os
 import subprocess
-import re
 import datetime
 import traceback
 import glob
 import multiprocessing
 import random
-import hisatgenotype_args as arguments
-import hisatgenotype_typing_common as typing_common
+from datetime import datetime, date
+from argparse import ArgumentParser
 
-from datetime import datetime, date, time
-from argparse import ArgumentParser, FileType
-from hisatgenotype_typing_core import genotyping_locus
-from hisatgenotype_typing_process import extract_reads, extract_vars
+import hisatgenotype_modules.hisatgenotype_args as arguments
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+from hisatgenotype_modules.hisatgenotype_typing_core import genotyping_locus
+from hisatgenotype_modules.hisatgenotype_typing_process import extract_reads, extract_vars
 
 # --------------------------------------------------------------------------- #
 # Auxillary functions for wraper script                                       #
@@ -606,7 +605,8 @@ def typing_process(args):
                              args.verbose_level,
                              args.assembly_verbose,
                              args.out_dir,
-                             debug)
+                             debug,
+                             args.core_fid)
     else:
         log = {} # build log to capture errors
         pool = multiprocessing.Pool(int(args.threads), 
@@ -659,7 +659,8 @@ def typing_process(args):
                             args.verbose_level,
                             args.assembly_verbose,
                             args.out_dir,
-                            debug)
+                            debug,
+                            args.core_fid)
                     )
 
         # Generate Log files for errors

--- a/hisatgenotype_modules/hisatgenotype_args.py
+++ b/hisatgenotype_modules/hisatgenotype_args.py
@@ -21,11 +21,6 @@
 
 import sys
 import os
-import subprocess
-import re
-import random
-import argparse
-from datetime import datetime
 
 # --------------------------------------------------------------------------- #
 #   Common Arguments                                                          #
@@ -43,6 +38,11 @@ def args_common(parser,
                         dest='verbose',
                         action='store_true',
                         help='Print statistics to stderr')
+    parser.add_argument("--core-fid",
+                        dest="core_fid",
+                        type=str,
+                        default=None,
+                        help="Core file id serves as output file prefix")
     if debug:
         parser.add_argument("--debug",
                             dest="debug",

--- a/hisatgenotype_modules/hisatgenotype_assembly_graph.py
+++ b/hisatgenotype_modules/hisatgenotype_assembly_graph.py
@@ -27,7 +27,7 @@ import os
 from datetime import datetime, date, time
 from collections import deque
 from copy import deepcopy
-import hisatgenotype_validation_check as validation_check
+import hisatgenotype_modules.hisatgenotype_validation_check as validation_check
 
 """ Flag to turn on file debugging to run sanity checks """
 setting_file = '/'.join(os.path.realpath(__file__).split('/')[:-2])\

--- a/hisatgenotype_modules/hisatgenotype_typing_common.py
+++ b/hisatgenotype_modules/hisatgenotype_typing_common.py
@@ -27,10 +27,6 @@ import math
 import random
 import errno
 import json
-from copy import deepcopy
-from datetime import datetime
-import hisatgenotype_typing_process as typing_process
-import hisatgenotype_validation_check as validation_check
 
 """ Flag to turn on file debugging to run sanity checks """
 setting_file = '/'.join(os.path.realpath(__file__).split('/')[:-2])\
@@ -538,6 +534,9 @@ def extract_database_if_not_exists(base,
                                    intra_gap = 50,
                                    partial = True,
                                    verbose = False):
+
+    import hisatgenotype_modules.hisatgenotype_typing_process as typing_process
+
     full_base = ix_dir + "/" + base
     fnames = [full_base + "_backbone.fa",
               full_base + "_sequences.fa",
@@ -570,7 +569,7 @@ def extract_database_if_not_exists(base,
               file=sys.stderr)
 
     if not check_files(fnames):
-        print("Error: hisatgenotype_extract_vars failed!", 
+        print("Error: hisatgenotype_extract_vars failed!",
               file=sys.stderr)
         sys.exit(1)
 
@@ -1669,6 +1668,9 @@ def identify_ambigious_diffs(ref_seq,
                              cmp_list,
                              verbose,
                              debug = False):
+
+    import hisatgenotype_modules.hisatgenotype_validation_check as validation_check
+
     cmp_left      = 0 
     cmp_right     = len(cmp_list) - 1
     left          = cmp_list[0][1]

--- a/hisatgenotype_modules/hisatgenotype_typing_process.py
+++ b/hisatgenotype_modules/hisatgenotype_typing_process.py
@@ -24,13 +24,11 @@ import os
 import subprocess
 import re
 import resource
-import inspect
-import random
 import glob
-import multiprocessing
 import json
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_validation_check as validation_check
+
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+import hisatgenotype_modules.hisatgenotype_validation_check as validation_check
 
 """ Flag to turn on file debugging to run sanity checks """
 setting_file = '/'.join(os.path.realpath(__file__).split('/')[:-2])\

--- a/hisatgenotype_modules/hisatgenotype_validation_check.py
+++ b/hisatgenotype_modules/hisatgenotype_validation_check.py
@@ -20,7 +20,8 @@
 # --------------------------------------------------------------------------- #
 
 import sys
-import hisatgenotype_typing_common as typing_common
+
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
 
 # --------------------------------------------------------------------------- #
 # Sorting Unit tests                                                          #

--- a/hisatgenotype_toolkit
+++ b/hisatgenotype_toolkit
@@ -22,14 +22,8 @@
 import sys
 import os
 import subprocess
-import re 
-import resource
-import inspect
-import random
-import math
-from datetime import datetime, date, time
-from argparse import ArgumentParser, FileType
-import hisatgenotype_typing_common as typing_common
+
+from argparse import ArgumentParser
 
 # --------------------------------------------------------------------------- #
 # Main function for wrapper that contains all functions                       #

--- a/hisatgenotype_tools/hisatgenotype_build_genome.py
+++ b/hisatgenotype_tools/hisatgenotype_build_genome.py
@@ -22,12 +22,10 @@
 import os
 import sys
 import subprocess
-import re
 import shutil
-import inspect
-from argparse import ArgumentParser, FileType
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_args as arguments
+from argparse import ArgumentParser
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+import hisatgenotype_modules.hisatgenotype_args as arguments
 
 # --------------------------------------------------------------------------- #
 #  General Functions                                                          #

--- a/hisatgenotype_tools/hisatgenotype_call_variants.py
+++ b/hisatgenotype_tools/hisatgenotype_call_variants.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 
-import sys, os, subprocess, re
-import itertools
-from multiprocessing import Pool
+import sys, os, subprocess
 from argparse import ArgumentParser
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_args as arguments
+import hisatgenotype_modules.hisatgenotype_args as arguments
 
 
 """ WORK IN PROGRESS

--- a/hisatgenotype_tools/hisatgenotype_convert_codis.py
+++ b/hisatgenotype_tools/hisatgenotype_convert_codis.py
@@ -19,15 +19,13 @@
 # along with HISAT-genotype.  If not, see <http://www.gnu.org/licenses/>.     #
 # --------------------------------------------------------------------------- #
 
-import os
 import sys
 import subprocess
-import re
-import inspect, operator
 from copy import deepcopy
-from argparse import ArgumentParser, FileType
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_args as arguments
+from argparse import ArgumentParser
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+import hisatgenotype_modules.hisatgenotype_args as arguments
+
 try:
     import openpyxl
 except ImportError:

--- a/hisatgenotype_tools/hisatgenotype_extract_RBG.py
+++ b/hisatgenotype_tools/hisatgenotype_extract_RBG.py
@@ -26,9 +26,9 @@ import re
 import urllib2
 import xml.etree.ElementTree as etree
 from multiprocessing import Pool
-from argparse import ArgumentParser, FileType
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_args as arguments
+from argparse import ArgumentParser
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+import hisatgenotype_modules.hisatgenotype_args as arguments
 
 # --------------------------------------------------------------------------- #
 # Download RBC data from website                                              #

--- a/hisatgenotype_tools/hisatgenotype_extract_codis_data.py
+++ b/hisatgenotype_tools/hisatgenotype_extract_codis_data.py
@@ -19,14 +19,10 @@
 # along with HISAT 2.  If not, see <http://www.gnu.org/licenses/>.            #
 # --------------------------------------------------------------------------- #
 
-import os
-import sys
 import subprocess
 import re
-import inspect
-import operator
-from argparse import ArgumentParser, FileType
-import hisatgenotype_args as arguments
+from argparse import ArgumentParser
+import hisatgenotype_modules.hisatgenotype_args as arguments
 
 # sequences for DNA fingerprinting loci are available at 
 # http://www.cstl.nist.gov/biotech/strbase/seq_ref.htm

--- a/hisatgenotype_tools/hisatgenotype_extract_reads.py
+++ b/hisatgenotype_tools/hisatgenotype_extract_reads.py
@@ -21,11 +21,9 @@
 
 import sys
 import os
-import subprocess
-import re
 from argparse import ArgumentParser, FileType
-from hisatgenotype_typing_process import extract_reads
-import hisatgenotype_args as arguments
+from hisatgenotype_modules.hisatgenotype_typing_process import extract_reads
+import hisatgenotype_modules.hisatgenotype_args as arguments
 
 # --------------------------------------------------------------------------- #
 # This is the Wrapper script that runs the processing code found in           #

--- a/hisatgenotype_tools/hisatgenotype_extract_vars.py
+++ b/hisatgenotype_tools/hisatgenotype_extract_vars.py
@@ -21,13 +21,11 @@
 
 import os
 import sys
-import subprocess
-import re
 import multiprocessing
-from argparse import ArgumentParser, FileType
-from hisatgenotype_typing_process import extract_vars
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_args as arguments
+from argparse import ArgumentParser
+from hisatgenotype_modules.hisatgenotype_typing_process import extract_vars
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+import hisatgenotype_modules.hisatgenotype_args as arguments
 
 def init(l):
     global lock

--- a/hisatgenotype_tools/hisatgenotype_legacy.py
+++ b/hisatgenotype_tools/hisatgenotype_legacy.py
@@ -21,14 +21,11 @@
 
 import sys
 import os
-import subprocess 
-import re
+import subprocess
 import resource
-import inspect, random
-import math
-from datetime import datetime, date, time
-from argparse import ArgumentParser, FileType
-import hisatgenotype_typing_common as typing_common
+from datetime import datetime
+from argparse import ArgumentParser
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
 
 
 # --------------------------------------------------------------------------- #

--- a/hisatgenotype_tools/hisatgenotype_locus.py
+++ b/hisatgenotype_tools/hisatgenotype_locus.py
@@ -21,13 +21,11 @@
 
 import sys
 import os
-import subprocess
-import re
 import random
-from argparse import ArgumentParser, FileType
-from hisatgenotype_typing_core import genotyping_locus
-import hisatgenotype_args as arguments
-import hisatgenotype_typing_core as typing_core
+from argparse import ArgumentParser
+
+import hisatgenotype_modules.hisatgenotype_args as arguments
+import hisatgenotype_modules.hisatgenotype_typing_core as typing_core
 
 # --------------------------------------------------------------------------- #
 # This is the Wrapper script that runs the core code found in                 #
@@ -187,5 +185,6 @@ if __name__ == '__main__':
                      args.verbose_level,
                      args.assembly_verbose,
                      args.out_dir,
-                     debug)
+                     debug,
+                     args.core_fid)
 

--- a/hisatgenotype_tools/hisatgenotype_locus_samples.py
+++ b/hisatgenotype_tools/hisatgenotype_locus_samples.py
@@ -22,14 +22,11 @@
 import sys
 import os
 import subprocess
-import re
 import threading
-import inspect
-import random
 import glob
-from argparse import ArgumentParser, FileType
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_args as arguments
+from argparse import ArgumentParser
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+import hisatgenotype_modules.hisatgenotype_args as arguments
 
 
 # Platinum genomes - CEPH pedigree (17 family members)

--- a/hisatgenotype_tools/hisatgenotype_parse_results.py
+++ b/hisatgenotype_tools/hisatgenotype_parse_results.py
@@ -19,12 +19,10 @@
 # along with HISAT-genotype.  If not, see <http://www.gnu.org/licenses/>.     #
 # --------------------------------------------------------------------------- #
 
-import os
-import sys
 import glob
 from argparse import ArgumentParser
-import hisatgenotype_typing_common as typing_common
-import hisatgenotype_args as hg_args
+import hisatgenotype_modules.hisatgenotype_typing_common as typing_common
+import hisatgenotype_modules.hisatgenotype_args as hg_args
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Changes made:

1. Correct all the imports
2. Pass `args.already_extract` to `genotyping_locus` so it only downloads genome and index files when needed.
3. Added `--core-fid` as an input parameter. Currently output file prefix is the basename of the input fastq file (for paired fastq files, one file will be randomly chosen and thus the output filename can have either _1 or _2 at the end). Passing `--core-fid` can avoid this random behavior.  